### PR TITLE
fix: reject non-WEBP RIFF uploads and rescue Vips::Error

### DIFF
--- a/lib/dynamic_image/format.rb
+++ b/lib/dynamic_image/format.rb
@@ -3,7 +3,7 @@
 module DynamicImage
   class Format
     attr_reader :name, :animated, :content_types, :extensions, :magic_bytes,
-                :save_options
+                :save_options, :signature
 
     def initialize(name, options)
       options = default_options.merge(options)
@@ -15,11 +15,18 @@ module DynamicImage
       @magic_bytes = options[:magic_bytes].map do |s|
         s.dup.force_encoding("binary")
       end
+      @signature = options[:signature]
       @save_options = options[:save_options]
     end
 
     def animated?
       animated
+    end
+
+    def matches?(bytes)
+      return false unless magic_bytes.any? { |b| bytes.start_with?(b) }
+
+      signature.nil? || signature.call(bytes)
     end
 
     def content_type
@@ -56,12 +63,7 @@ module DynamicImage
       def sniff(bytes)
         return unless bytes
 
-        formats.each do |format|
-          format.magic_bytes.each do |b|
-            return format if bytes.start_with?(b)
-          end
-        end
-        nil
+        formats.find { |format| format.matches?(bytes) }
       end
 
       private
@@ -73,7 +75,7 @@ module DynamicImage
 
     def default_options
       { animated: false, content_type: [], extension: [], magic_bytes: [],
-        save_options: {} }
+        signature: nil, save_options: {} }
     end
 
     register(
@@ -119,6 +121,7 @@ module DynamicImage
       content_type: %w[image/webp],
       extension: %w[.webp],
       magic_bytes: ["\x52\x49\x46\x46"],
+      signature: ->(bytes) { bytes.bytesize >= 12 && bytes[8, 4] == "WEBP" },
       save_options: { Q: 90, strip: true }
     )
   end

--- a/lib/dynamic_image/image_reader.rb
+++ b/lib/dynamic_image/image_reader.rb
@@ -2,6 +2,8 @@
 
 module DynamicImage
   class ImageReader
+    HEADER_BYTES = 12
+
     def initialize(data)
       @data = data
     end
@@ -37,10 +39,10 @@ module DynamicImage
 
     def read_file_header
       if @data.is_a?(Pathname)
-        File.binread(@data.to_s, 8)
+        File.binread(@data.to_s, HEADER_BYTES)
       else
         data_stream = stream
-        header = data_stream.read(8)
+        header = data_stream.read(HEADER_BYTES)
         data_stream.seek(0 - header.length, IO::SEEK_CUR) if header
         header
       end

--- a/lib/dynamic_image/metadata.rb
+++ b/lib/dynamic_image/metadata.rb
@@ -65,17 +65,21 @@ module DynamicImage
 
     def read_metadata
       image = reader.read
+      width, height = dimensions_from(image)
+      width, height = height, width if rotated?(image)
+      { width:, height:, colorspace: image.get("interpretation") }
+    rescue Vips::Error
+      :invalid
+    end
 
+    def dimensions_from(image)
       width = image.get("width")
       height = if image.get_fields.include?("page-height")
                  image.get("page-height")
                else
                  image.get("height")
                end
-
-      width, height = height, width if rotated?(image)
-
-      { width:, height:, colorspace: image.get("interpretation") }
+      [width, height]
     end
 
     def orientation(image)

--- a/spec/dynamic_image/format_spec.rb
+++ b/spec/dynamic_image/format_spec.rb
@@ -35,6 +35,24 @@ describe DynamicImage::Format do
 
       it { is_expected.to be_nil }
     end
+
+    context "when byte sequence is a non-WEBP RIFF container (e.g. WAV)" do
+      let(:bytes) { "RIFF\x24\x00\x00\x00WAVEfmt ".b }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when byte sequence is a valid WEBP header" do
+      let(:bytes) { "RIFF\x24\x00\x00\x00WEBPVP8 ".b }
+
+      it { is_expected.to eq(find_format("WEBP")) }
+    end
+
+    context "when byte sequence is RIFF but truncated below 12 bytes" do
+      let(:bytes) { "RIFF\x24\x00\x00".b }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#content_type" do

--- a/spec/dynamic_image/metadata_spec.rb
+++ b/spec/dynamic_image/metadata_spec.rb
@@ -210,5 +210,16 @@ describe DynamicImage::Metadata do
 
       it { is_expected.to be false }
     end
+
+    context "when the header sniffs as valid but vips fails to load it" do
+      before do
+        reader = instance_double(DynamicImage::ImageReader, valid_header?: true)
+        allow(reader).to receive(:read)
+          .and_raise(Vips::Error.new("not a known file format"))
+        allow(DynamicImage::ImageReader).to receive(:new).and_return(reader)
+      end
+
+      it { is_expected.to be false }
+    end
   end
 end


### PR DESCRIPTION
## Summary

- WEBP sniffing only matched the `RIFF` prefix, so any other RIFF container (WAV, AVI, ANI…) was classified as WEBP and then crashed in libvips with `VipsForeignLoad: ... is not a known file format`. Tighten the check by also requiring the `WEBP` fourcc at offset 8 (via a new `signature:` option on `Format`).
- `Metadata#read_metadata` didn't rescue `Vips::Error`, so a vips-side load failure on a corrupt or partially-uploaded file became an unhandled 500 instead of a model validation error. Now returns `:invalid`, which makes `valid?` return false and trips the existing `valid_image?` validation cleanly.
- Bump the header read from 8 → 12 bytes so the signature check can see the fourcc at offset 8.

Fixes a production Sentry error (Anyone Oslo internal: BYLARM-2M).

## Test plan

- [x] `bundle exec rspec` — 315 examples, 0 failures
- [x] `bundle exec rubocop lib/... spec/...` — clean
- [x] New spec: non-WEBP RIFF (WAV header) no longer sniffs as WEBP
- [x] New spec: valid WEBP header still sniffs as WEBP
- [x] New spec: truncated RIFF (<12 bytes) returns nil
- [x] New spec: `Metadata#valid?` is false when `ImageReader#read` raises `Vips::Error`
